### PR TITLE
Fix/#5 도서관 재고 검색 화면 버벅거림 해결

### DIFF
--- a/components/organisms/LibraryMap.tsx
+++ b/components/organisms/LibraryMap.tsx
@@ -175,7 +175,7 @@ export const LibraryMap = ({
               borderRadius: "0.5rem",
             }}
             level={mapBound.clusterdLevel}
-            onBoundsChanged={handleBoundsChanged}
+            onIdle={handleBoundsChanged}
           >
             <MarkerClusterer
               averageCenter={true}


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- #5 

## 이후 PR 계획
- 도서관 정보 fetch를 page.tsx에 두는 게 아니라 템플릿 하위로 이동하는 리팩터링 필요

## 참고
- [Kakao-Map idle Event](https://apis.map.kakao.com/web/documentation/#Map_idle)
- [Kakao-Map bounds_changed Event](https://apis.map.kakao.com/web/documentation/#Map_bounds_changed)
 
