### PR TITLE
fix: 도서관 선택 맵 페이지의 mapBound를 useState로 사용하고 useEffect에서 쿠키 관련 로직을 실행하…

### DIFF
--- a/app/libraries/map/select/page.tsx
+++ b/app/libraries/map/select/page.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 import LibraryMarkerInfo from "@/types/LibraryMarkerInfo";
 
 import {
+  DEFAULT_MAP_BOUND,
   findMapLocationProps,
   setMapLocationProps,
 } from "@/utils/MapLocalStorage";
@@ -16,13 +17,14 @@ import { LibrarySelectionMapTemplate } from "@/components/templates/LibrarySelec
 
 export default function LibrariesSelection() {
   const [libraries, setLibraries] = useState<LibraryMarkerInfo[]>([]);
+  const [initMapBound, setInitMapBound] = useState<MapBound>(DEFAULT_MAP_BOUND);
 
   const MAP_SEARCH_DELAY = 275;
   const CULSTERD_LEVEL = 8;
 
-  const mapBound: MapBound = findMapLocationProps();
-
   useEffect(() => {
+    const mapBound = findMapLocationProps();
+    setInitMapBound(mapBound);
     findLibraries(mapBound);
   }, []);
 
@@ -55,7 +57,7 @@ export default function LibrariesSelection() {
       {/* <LibraryPage /> */}
       <div className="w-full">
         <LibrarySelectionMapTemplate
-          mapBound={mapBound}
+          mapBound={initMapBound}
           libraries={libraries}
           onBoundsChange={debouncedMapSearch}
         />

--- a/utils/MapLocalStorage.ts
+++ b/utils/MapLocalStorage.ts
@@ -2,7 +2,7 @@ import { MapBound } from "@/types/MapBound";
 
 const STORAGE_NAME = "MAP_LOCATION";
 
-const DEFAULT_MAP_BOUND: MapBound = new MapBound(
+export const DEFAULT_MAP_BOUND: MapBound = new MapBound(
   {
     latitude: 37.57027567568552,
     longitude: 126.97290367316594,


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
-  도서관 선택 맵 페이지의 mapBound를 useState로 사용하고 useEffect에서 쿠키 관련 로직을 실행하도록 변경
```
Error occurred prerendering page "/libraries/map/select". Read more: https://nextjs.org/docs/messages/prerender-error
ReferenceError: document is not defined
    at /vercel/path0/.next/server/chunks/166.js:1:7760
    at i (/vercel/path0/.next/server/chunks/166.js:1:7845)
    at W (/vercel/path0/.next/server/app/libraries/map/select/page.js:17:2759)
    at nO (/vercel/path0/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:20:45959)
    at nI (/vercel/path0/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:20:47734)
    at nL (/vercel/path0/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:20:65533)
    at nN (/vercel/path0/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:20:63164)
    at n$ (/vercel/path0/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:20:46311)
    at nI (/vercel/path0/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:20:47780)
    at nI (/vercel/path0/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:20:62515)
Export encountered an error on /libraries/map/select/page: /libraries/map/select, exiting the build.
 ⨯ Static worker exited with code: 1 and signal: null
Error: Command "npm run build" exited with 1
```

<!--
 (optional) 참고한 사이트
## 참고
-
-->
 
