### PR TITLE
fix: 북카트 페이지에 책 정보가 존재하지 않을 때 관련없는 책들이 검색되는 버그 수정

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -4,6 +4,7 @@ import { cookies } from "next/headers";
 import { STORAGE_NAME } from "@/utils/BookCartLocalStorage";
 import { BookCartListTemplate } from "@/components/templates/BookCartListTemplate";
 import { BookCartPopup } from "@/components/organisms/BookCartPopup";
+import { BookPreview } from "@/types/BookPreview";
 
 const MAX_CART_SIZE = 20;
 const FIRST_PAGE = 0;
@@ -22,13 +23,20 @@ export default async function Cart({
   const cookieVal = (await cookies()).get(STORAGE_NAME)?.value ?? "[]";
   const bookIds: string[] = JSON.parse(cookieVal);
 
-  const { books } = await findBooksPreview(
-    {
-      keyword: keyword,
-      bookIds: bookIds,
-    },
-    CART_PAGEABLE
-  );
+  const books = await findBookCartList(bookIds);
+
+  async function findBookCartList(bookIds: string[]): Promise<BookPreview[]> {
+    if (bookIds.length === 0) return Promise.resolve([]);
+    return (
+      await findBooksPreview(
+        {
+          keyword: keyword,
+          bookIds: bookIds,
+        },
+        CART_PAGEABLE
+      )
+    ).books;
+  }
 
   return (
     <div className="min-h-screen bg-background px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- 북카트 페이지에 책 정보가 존재하지 않을 때 관련없는 책들이 검색되는 버그 수정

<!--
 (optional) 참고한 사이트
## 참고
-
-->
 
