### PR TITLE
Feat/#66 자잘한 기능 추가 및 수정

### DIFF
--- a/app/libraries/map/select/page.tsx
+++ b/app/libraries/map/select/page.tsx
@@ -13,6 +13,8 @@ import {
   setMapLocationProps,
 } from "@/utils/MapLocalStorage";
 import { LibrarySelectionMapTemplate } from "@/components/templates/LibrarySelectionMapTemplate";
+import { MapLimitInfo } from "@/components/organisms/MapLimitInfo";
+import { InfoPanel } from "@/components/molecules/InfoPanel";
 
 export default function LibrariesSelection() {
   const [libraries, setLibraries] = useState<LibraryMarkerInfo[]>([]);
@@ -60,6 +62,8 @@ export default function LibrariesSelection() {
           onBoundsChange={debouncedMapSearch}
         />
       </div>
+
+      <InfoPanel text="책을 검색하고 싶은 도서관 찾고, 클릭하면 등장하는 패널에서 '도서관 선택' 버튼을 눌러주세요." />
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,6 +54,7 @@ export default async function Home({ searchParams }: Props) {
   let books: BookPreview[];
   let searchAfter: SearchAfter;
   let hasNext: boolean;
+  let totalElements = null;
 
   const hasCursorCond = lastLoanCount !== null && lastBookId !== null;
   const isOutOfPageNumber: boolean = page > MAX_NUMBER_PAGE;
@@ -79,12 +80,14 @@ export default async function Home({ searchParams }: Props) {
     totalPages = null;
     searchAfter = result.searchAfter;
     hasNext = result.hasNext;
+    totalElements = result.totalElements;
   } else {
     const result = await findBooksPreview(searchCond, pageable);
     books = result.books;
     totalPages = result.totalPage;
     searchAfter = result.searchAfter;
     hasNext = result.hasNext;
+    totalElements = result.totalElements;
   }
 
   return (
@@ -94,6 +97,7 @@ export default async function Home({ searchParams }: Props) {
         bookQueryString={toRawQueryString(await searchParams)}
         libraryId={libraryId}
         categoryId={categoryId}
+        totalElements={totalElements}
       />
 
       <BookPreviewList searchResults={books} />

--- a/components/atoms/BookSpotLogoLink.tsx
+++ b/components/atoms/BookSpotLogoLink.tsx
@@ -2,8 +2,8 @@ import Link from "next/link";
 
 export const BookSpotLogoButton = () => {
   return (
-    <Link href="/" className="text-2xl font-bold text-primary">
+    <a href="/" className="text-2xl font-bold text-primary">
       BookSpot
-    </Link>
+    </a>
   );
 };

--- a/components/molecules/BookPreviewInfo.tsx
+++ b/components/molecules/BookPreviewInfo.tsx
@@ -35,7 +35,9 @@ export const BookPreviewInfo = ({ book }: BookPreviewInfoProps) => {
         />
       </p>
       <div className="mt-auto pt-2">
-        <CardFooterLabel text={`📖 ${formatCount(book.loanCount, "회")}`} />
+        <CardFooterLabel
+          text={`📖 ${formatCount(book.loanCount, "회 대출")}`}
+        />
       </div>
     </div>
   );

--- a/components/molecules/SearchBar.tsx
+++ b/components/molecules/SearchBar.tsx
@@ -56,7 +56,7 @@ export const SearchBar = ({ initialSearchTerm }: SearchProps) => {
 
   // input 따로 뺄 것
   return (
-    <form onSubmit={handleSubmit} className="relative mb-6">
+    <form onSubmit={handleSubmit} className="relative">
       <input
         name="search"
         type="text"

--- a/components/molecules/link/CartIconLink.tsx
+++ b/components/molecules/link/CartIconLink.tsx
@@ -23,7 +23,7 @@ export const CartIconLink = ({ href, cartSize: size }: CartIconLinkProps) => {
   }, [size]);
 
   return (
-    <Link href={href} className="text-primary hover:text-primary/80 relative">
+    <a href={href} className="text-primary hover:text-primary/80 relative">
       <ShoppingCart
         size={24}
         className={`${isAnimating ? "animate-bump" : ""}`}
@@ -35,6 +35,6 @@ export const CartIconLink = ({ href, cartSize: size }: CartIconLinkProps) => {
           className={`${isAnimating ? "animate-bump" : ""}`}
         />
       )}
-    </Link>
+    </a>
   );
 };

--- a/components/organisms/BookSearchBar.tsx
+++ b/components/organisms/BookSearchBar.tsx
@@ -16,6 +16,7 @@ interface SearchProps {
   categoryId: number | null;
   bookQueryString?: string;
   initialSearchTerm: string;
+  totalElements: number;
 }
 
 export const BookSearchBar = async ({
@@ -23,18 +24,25 @@ export const BookSearchBar = async ({
   categoryId,
   bookQueryString,
   initialSearchTerm,
+  totalElements,
 }: SearchProps) => {
   return (
     <div className="w-full">
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex flex-wrap items-center justify-between">
+      <SearchBar initialSearchTerm={initialSearchTerm} />
+      <div className="grid grid-cols-[1fr_auto] gap-4 items-end w-full my-3">
+        <div className="flex flex-wrap justify-start gap-2">
           {await libraryFilterButton(libraryId)}
           {await categoryFilterButton(categoryId)}
         </div>
-        <div className="flex-1">{/* 빈 공간 */}</div>
-      </div>
 
-      <SearchBar initialSearchTerm={initialSearchTerm} />
+        <div className=" self-end justify-self-end pb-2 pe-2">
+          <span className="text-muted-foreground">
+            {totalElements >= 10_000
+              ? `10,000건 이상`
+              : `${totalElements.toLocaleString()} 건`}{" "}
+          </span>
+        </div>
+      </div>
     </div>
   );
 

--- a/components/organisms/Header.tsx
+++ b/components/organisms/Header.tsx
@@ -20,34 +20,12 @@ export const Header = () => {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  const getPageTitle = () => {
-    switch (pathname) {
-      case "/":
-        return "";
-      case "/cart":
-        return "북카트";
-      case "/libraries/stock/search":
-      case "/libraries/stock/map":
-      case "/libraries/map/select":
-        return "도서관 검색";
-      default:
-        if (pathname.startsWith("/book")) {
-          return "책 검색";
-        }
-        if (pathname.startsWith("/libraries") && pathname.endsWith("books")) {
-          return "도서관 책 검색";
-        }
-        return "???";
-    }
-  };
-
   return (
     <header
       className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${isScrolled ? "bg-background/80 backdrop-blur-sm" : "bg-background"}`}
     >
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
         <BookSpotLogoButton />
-        <h1 className="text-xl font-semibold text-primary">{getPageTitle()}</h1>
         <CartIconLink href="/cart" cartSize={cart.length} />
       </div>
     </header>

--- a/types/Pageable.ts
+++ b/types/Pageable.ts
@@ -1,4 +1,4 @@
-export const MAX_NUMBER_PAGE = 10;
+export const MAX_NUMBER_PAGE = 50;
 
 export const ITEMS_PER_PAGE = 12;
 export const FIRST_PAGE = 1;

--- a/types/Pageable.ts
+++ b/types/Pageable.ts
@@ -1,4 +1,4 @@
-export const MAX_NUMBER_PAGE = 50;
+export const MAX_NUMBER_PAGE = 10;
 
 export const ITEMS_PER_PAGE = 12;
 export const FIRST_PAGE = 1;


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- #66 

- 대출 키워드 추가
<img width="113" height="34" alt="image" src="https://github.com/user-attachments/assets/ea462c3e-1648-421d-b717-646e4a9e5788" />

- Header 타이틀 제거 + Header에서 카트나 홈 페이지 이동시 Link 태그 대신  a태그로 이동하도록 변경

- 검색 관련 레이아웃 변경 + 전체 검색 결과 수 표시
<img width="918" height="139" alt="image" src="https://github.com/user-attachments/assets/5f6f8e5a-93fa-4f64-91d7-4e29d5d04869" />

- 도서관 선택 시 정보 패널 추가
<img width="897" height="802" alt="image" src="https://github.com/user-attachments/assets/4adf2415-1d09-4094-b911-c34b50341aad" />


<!--
 (optional) 참고한 사이트
## 참고
-
-->
 
