### PR TITLE
vercel 이미지 최적화 무료 용량 초과로 이미지 안보임 버그 수정

### DIFF
--- a/components/molecules/BookPreviewImage.tsx
+++ b/components/molecules/BookPreviewImage.tsx
@@ -21,6 +21,7 @@ export const BookPreviewImage = ({ id, title, isbn13 }: BookImageProps) => {
           fill
           sizes="(max-width: 768px) 50vw, 33vw"
           className="object-contain"
+          unoptimized
         />
       </div>
     </a>


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- vercel 이미지 최적화 무료 용량 초과로 이미지 안보임 버그 수정

