### PR TITLE
fix: SearchTErmContext에서 useSearchParams를 사용하지 않도록 변경

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,6 +101,7 @@ export default async function Home({ searchParams }: Props) {
         totalElements={totalElements}
       />
       <BookSearchBar
+        initSearchTerm={searchTerm}
         bookQueryString={toRawQueryString(await searchParams)}
         libraryId={libraryId}
         categoryId={categoryId}

--- a/components/molecules/SearchBar.tsx
+++ b/components/molecules/SearchBar.tsx
@@ -9,20 +9,20 @@ import { Search } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useTransition } from "react";
 import { XButton } from "../atoms/button/icon/XButton";
-import { SEARCH_TERM_KEY } from "@/utils/querystring/SearchTerm";
 import { useSearchTerm } from "@/contexts/SearchTermContext";
 
-interface SearchProps {}
+interface SearchProps {
+  initSearchTerm: string | null;
+}
 
-export const SearchBar = ({}: SearchProps) => {
-  const { searchTerm, setSearchTerm, clearSearchTerm } = useSearchTerm();
+export const SearchBar = ({ initSearchTerm }: SearchProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
+  const { searchTerm, setSearchTerm, clearSearchTerm } = useSearchTerm();
 
   useEffect(() => {
-    const initTerm = searchParams.get(SEARCH_TERM_KEY);
-    setSearchTerm(initTerm === null ? "" : initTerm);
+    setSearchTerm(initSearchTerm === null ? "" : initSearchTerm);
   }, []);
 
   // 검색 폼 제출 처리

--- a/components/organisms/search/BookSearchBar.tsx
+++ b/components/organisms/search/BookSearchBar.tsx
@@ -2,19 +2,21 @@ import { SearchBar } from "@/components/molecules/SearchBar";
 import { FilterStatusGroup } from "./FilterStatusGroup";
 
 interface SearchProps {
+  initSearchTerm: string | null;
   libraryId: number | null;
   categoryId: number | null;
   bookQueryString?: string;
 }
 
 export const BookSearchBar = async ({
+  initSearchTerm,
   libraryId,
   categoryId,
   bookQueryString,
 }: SearchProps) => {
   return (
     <div className="w-full">
-      <SearchBar />
+      <SearchBar initSearchTerm={initSearchTerm} />
       <FilterStatusGroup
         categoryId={categoryId}
         libraryId={libraryId}

--- a/contexts/SearchTermContext.tsx
+++ b/contexts/SearchTermContext.tsx
@@ -2,8 +2,6 @@
 
 import type React from "react";
 import { createContext, useContext, useState, useEffect } from "react";
-import { useSearchParams } from "next/navigation";
-import { SEARCH_TERM_KEY } from "@/utils/querystring/SearchTerm";
 
 type SearchTermContextType = {
   searchTerm: string;
@@ -26,13 +24,6 @@ export const useSearchTerm = () => {
 type SearchTermProviderProps = { children: React.ReactNode };
 export const SearchTermProvider = ({ children }: SearchTermProviderProps) => {
   const [searchTerm, setSearchTerm] = useState<string>("");
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    const initTerm = searchParams.get(SEARCH_TERM_KEY);
-    setSearchTerm(initTerm === null ? "" : initTerm);
-  }, []);
-
   const clearSearchTerm = () => setSearchTerm("");
 
   return (


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- SearchTErmContext에서 useSearchParams를 사용하지 않도록 변경

<!--
 (optional) 참고한 사이트
## 참고
-
-->
 
