### PR TITLE
Feat/#129 로직 없는 로그인 페이지 추가 

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,30 @@
+import { GoogleLoginButton } from "@/components/molecules/button/login/GoogleLoginButton";
+import { KakaoLoginButton } from "@/components/molecules/button/login/KakaoLoginButton";
+import { NaverLoginButton } from "@/components/molecules/button/login/NaverLoginButton";
+import { Button } from "@/components/ui/button";
+
+export default async function LoginPage() {
+  return (
+    <div
+      className="flex items-center justify-center p-4"
+      style={{ height: "calc(100vh - 64px - 64px)" }}
+    >
+      <div className="w-full max-w-md">
+        <div className="backdrop-blur-sm bg-card/80 border border-border/50 rounded-2xl p-6 shadow-2xl max-h-[80vh] overflow-auto">
+          <div className="text-center space-y-4 mb-8">
+            <h1 className="text-3xl font-bold text-primary">BookSpot</h1>
+            <p className="text-muted-foreground">
+              소셜 계정으로 빠르게 시작하세요
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <NaverLoginButton />
+            <KakaoLoginButton />
+            <GoogleLoginButton />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,7 @@
 import { GoogleLoginButton } from "@/components/molecules/button/login/GoogleLoginButton";
 import { KakaoLoginButton } from "@/components/molecules/button/login/KakaoLoginButton";
 import { NaverLoginButton } from "@/components/molecules/button/login/NaverLoginButton";
-import { Button } from "@/components/ui/button";
+import { OauthLoginButtonGroup } from "@/components/organisms/OauthLoginButtonGroup";
 
 export default async function LoginPage() {
   return (
@@ -18,11 +18,7 @@ export default async function LoginPage() {
             </p>
           </div>
 
-          <div className="space-y-4">
-            <NaverLoginButton />
-            <KakaoLoginButton />
-            <GoogleLoginButton />
-          </div>
+          <OauthLoginButtonGroup />
         </div>
       </div>
     </div>

--- a/components/molecules/button/login/GoogleLoginButton.tsx
+++ b/components/molecules/button/login/GoogleLoginButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  onClick?: () => void;
+}
+
+export const GoogleLoginButton = ({ onClick = () => {} }: Props) => {
+  return (
+    <Button
+      className="w-full h-14 bg-white hover:bg-gray-50 text-gray-700 font-medium rounded-xl border-2 border-gray-200 transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
+      onClick={onClick}
+    >
+      <div className="flex items-center gap-3">
+        <div className="w-6 h-6 bg-gradient-to-r from-blue-500 via-red-500 to-yellow-500 rounded flex items-center justify-center">
+          <span className="text-white font-bold text-sm">G</span>
+        </div>
+        구글로 계속하기
+      </div>
+    </Button>
+  );
+};

--- a/components/molecules/button/login/KakaoLoginButton.tsx
+++ b/components/molecules/button/login/KakaoLoginButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  onClick?: () => void;
+}
+
+export const KakaoLoginButton = ({ onClick = () => {} }: Props) => {
+  return (
+    <Button
+      onClick={onClick}
+      className="w-full h-14 bg-yellow-400 hover:bg-yellow-500 text-black font-medium rounded-xl transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
+    >
+      <div className="flex items-center gap-3">
+        <div className="w-6 h-6 bg-black rounded flex items-center justify-center">
+          <span className="text-yellow-400 font-bold text-sm">K</span>
+        </div>
+        카카오로 계속하기
+      </div>
+    </Button>
+  );
+};

--- a/components/molecules/button/login/NaverLoginButton.tsx
+++ b/components/molecules/button/login/NaverLoginButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  onClick?: () => void;
+}
+
+export const NaverLoginButton = ({ onClick = () => {} }: Props) => {
+  return (
+    <Button
+      onClick={onClick}
+      className="w-full h-14 bg-green-500 hover:bg-green-600 text-white font-medium rounded-xl transition-all duration-200 hover:scale-[1.02] active:scale-[0.98]"
+    >
+      <div className="flex items-center gap-3">
+        <div className="w-6 h-6 bg-white rounded flex items-center justify-center">
+          <span className="text-green-500 font-bold text-sm">N</span>
+        </div>
+        네이버로 계속하기
+      </div>
+    </Button>
+  );
+};

--- a/components/organisms/OauthLoginButtonGroup.tsx
+++ b/components/organisms/OauthLoginButtonGroup.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { GoogleLoginButton } from "@/components/molecules/button/login/GoogleLoginButton";
+import { KakaoLoginButton } from "@/components/molecules/button/login/KakaoLoginButton";
+import { NaverLoginButton } from "@/components/molecules/button/login/NaverLoginButton";
+
+export const OauthLoginButtonGroup = () => {
+  return (
+    <div className="space-y-4">
+      <NaverLoginButton
+        onClick={() => {
+          console.log("네이버 로그인");
+        }}
+      />
+      <KakaoLoginButton
+        onClick={() => {
+          console.log("카카오 로그인");
+        }}
+      />
+      <GoogleLoginButton
+        onClick={() => {
+          console.log("구글 로그인");
+        }}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- #129 

<img width="709" height="523" alt="image" src="https://github.com/user-attachments/assets/0ab49e59-bb87-4f34-a7c7-1307a4716162" />


## 이 PR에서 다루지 않는 것
- onClick 이벤트를 단순 console 출력으로 놔둠

<!--
 (optional) 참고한 사이트
## 참고
-
-->
 
