### PR TITLE
Style/#154 헤더에 로그인한 사용자 / 비로그인 사용자가 구분되는 디자인으로 변경

### DIFF
--- a/components/organisms/Header.tsx
+++ b/components/organisms/Header.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { BookSpotLogoButton } from "../atoms/BookSpotLogoLink";
 import { BagIconLink } from "../molecules/link/BagIconLink";
 import { useBag } from "@/contexts/BagContext";
-import { User } from "lucide-react";
+import { UserCircle } from "lucide-react";
 import IconDropDownButton from "./dropdown/IconDrowDown";
 import { signOut, useSession } from "next-auth/react";
 
@@ -46,7 +46,7 @@ const UserIconButton = () => {
     <>
       {status === "authenticated" ? (
         <IconDropDownButton
-          Icon={User}
+          Icon={UserCircle}
           items={[
             { type: "link", text: "내 서재", href: "/library" },
             {
@@ -66,7 +66,7 @@ const UserIconButton = () => {
           className={`inline-flex items-center justify-center p-2 rounded-full transition-transform duration-150 hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 bg-transparent`}
           title="로그인"
         >
-          <User size={24} className="text-primary" />
+          <UserCircle size={24} className="text-muted-foreground" />
         </button>
       )}
     </>


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- #154 

- 로그인 전/후
<img width="100" height="43" alt="image" src="https://github.com/user-attachments/assets/02d37118-fc34-452f-9be5-16e2105bff0e" />

<img width="95" height="42" alt="image" src="https://github.com/user-attachments/assets/7ad10412-e3ab-4806-99a2-09e5282ea2e4" />


<!--
 (optional) 참고한 사이트
## 참고
-
-->
 
