### PR TITLE
Style/#175 대출 현황 미지원 도서관 화면 변경

### DIFF
--- a/components/molecules/LibraryStockPanel.tsx
+++ b/components/molecules/LibraryStockPanel.tsx
@@ -247,10 +247,8 @@ const BooksTap = ({
           <h3 className="text-sm font-semibold ps-2 text-gray-700">
             {supportsLoanStatus ? "대출 현황" : "도서 목록"}
           </h3>
-          {supportsLoanStatus ? (
+          {supportsLoanStatus && (
             <GreenBadge text="조회 가능" icon={<Check />} />
-          ) : (
-            <YellowBadge text="조회 제한" icon={<X />} />
           )}
         </div>
         {supportsLoanStatus && (

--- a/components/molecules/LibraryStockPanel.tsx
+++ b/components/molecules/LibraryStockPanel.tsx
@@ -264,7 +264,10 @@ const BooksTap = ({
           {books.map((book: LibraryBookStockInfo) => {
             return (
               <li key={book.bookId}>
-                <BookLoanStatePanel libraryBookStockInfo={book} />
+                <BookLoanStatePanel
+                  libraryBookStockInfo={book}
+                  supportsLoanStatus={supportsLoanStatus}
+                />
               </li>
             );
           })}

--- a/components/molecules/LibraryStockPanel.tsx
+++ b/components/molecules/LibraryStockPanel.tsx
@@ -269,7 +269,11 @@ const BooksTap = ({
             );
           })}
           <li>
-            <InfoPanel text="하루 전 대출 가능여부만 확인할 수 있습니다." />
+            {supportsLoanStatus ? (
+              <InfoPanel text="하루 전 대출 가능여부만 확인할 수 있습니다." />
+            ) : (
+              <InfoPanel text="도서 카드를 클릭해서 해당 도서관의 대출 현황을 파악해보세요." />
+            )}
           </li>
         </ul>
       ) : (

--- a/components/molecules/LibraryStockPanel.tsx
+++ b/components/molecules/LibraryStockPanel.tsx
@@ -245,7 +245,7 @@ const BooksTap = ({
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           <h3 className="text-sm font-semibold ps-2 text-gray-700">
-            대출 현황
+            {supportsLoanStatus ? "대출 현황" : "도서 목록"}
           </h3>
           {supportsLoanStatus ? (
             <GreenBadge text="조회 가능" icon={<Check />} />

--- a/components/molecules/panel/BookLoanStatePanel.tsx
+++ b/components/molecules/panel/BookLoanStatePanel.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/atoms/badge/TextLabelBadge";
 
 interface BookLoanStatePanelProps {
+  supportsLoanStatus: boolean;
   libraryBookStockInfo: LibraryBookStockInfo;
 }
 
@@ -42,6 +43,7 @@ function getTimeAgo(dateStr: string): string {
 }
 
 export const BookLoanStatePanel = ({
+  supportsLoanStatus,
   libraryBookStockInfo: stockInfo,
 }: BookLoanStatePanelProps) => {
   const bgColor = stockInfo.isInLibrary ? "bg-green-50" : "bg-red-50";
@@ -86,7 +88,7 @@ export const BookLoanStatePanel = ({
         <p className="text-xs text-gray-600 truncate mb-0.5">
           {subInfoLabelText()}
         </p>
-        {stockInfo.isInLibrary && (
+        {stockInfo.isInLibrary && supportsLoanStatus && (
           <LoanStatusLine loanInfo={stockInfo.loanInfo} />
         )}
       </div>


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- #175 

대출 현황 지원 여부에 따른 화면 구성 변경

<img width="537" height="249" alt="image" src="https://github.com/user-attachments/assets/5b6801c5-8135-4213-886c-701ac06afa4c" />

<img width="543" height="291" alt="image" src="https://github.com/user-attachments/assets/3af1611e-b053-4670-a68e-82cb64ea2532" />



<!--
 (optional) 참고한 사이트
## 참고
-
-->
 
