### PR TITLE
Fix/#253 로그인 만료가 안되는 문제 해결

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -4,8 +4,7 @@ import Naver from "next-auth/providers/naver";
 import Kakao from "next-auth/providers/kakao";
 
 export const { auth, handlers, signIn, signOut } = NextAuth({
-  // TODO: maxAge 하드코딩을 바꿔줘야함
-  session: { strategy: "jwt", maxAge: 60 * 60 * 24 * 3 },
+  session: { strategy: "jwt" },
   providers: [
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID,
@@ -50,11 +49,21 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
           token.userRole = backendData.role;
           token.userId = backendData.userId;
           token.exp = Math.floor(backendData.expiredAt / 1000);
+          token.expiresAtMs = backendData.expiredAt;
         } catch (error) {
           console.error("JWT Callback Error:", error);
           token.error = "BackendLoginError";
         }
       }
+
+      /*
+        첫 로그인 시도 시에만 user - account 값이 들어옴.
+        useSession, auth등등을 사용할 때는 user - account값이 안들어온채로 jwt 콜백이 실행됨 
+        그래서 다음과 같은 로직이 필요해짐
+      */
+      if (!token.expiresAtMs) return { ...token, exp: 0 }; // ms단위잘못된 토큰
+      if (Date.now() >= token.expiresAtMs) return { ...token, exp: 0 }; // 현재시간과 실제 만료시간 비교 후 만료시키기
+      token.exp = Math.floor((token.expiresAtMs as number) / 1000); // exp 덮어쓰기.
       return token;
     },
 

--- a/types/auth.d.ts
+++ b/types/auth.d.ts
@@ -18,5 +18,8 @@ declare module "next-auth/jwt" {
     backendToken?: string;
     userRole?: string;
     error?: string;
+
+    // exp는 초단위(next-auth에서 내부적으로 쓰는 값)
+    expiresAtMs?: number; // backendExpiresAt은 ms단위. Date와 호환.
   }
 }

--- a/utils/api/UsersApi.ts
+++ b/utils/api/UsersApi.ts
@@ -8,8 +8,12 @@ export const findMe = async ({
 }): Promise<UserDetailResponseSpec> => {
   const response = await getApiClient(side).get<void>(`/api/users/me`);
 
-  if (!response.ok) throw response.error;
-  if (!response.data) throw new Error("사용자 정보 없음");
+  if (!response.ok || !response.data)
+    return {
+      email: "로그아웃을 진행해주세요.",
+      createdAt: new Date().toLocaleDateString(),
+      provider: "로그아웃 필요",
+    };
   return response.data;
 };
 


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- #253 

## 참고
- next-auth의 jwt 콜백은 로그인때만 호출되는게 아니다.
- auth(), useSession 등등 세션을 조회해야 할 때 jwt 콜백은 늘 호출된다.
- next-auth 로그인 시에만 account, user가 들어오기 때문에 최초 로그인시에 토큰이 세팅되고, jwt를 호출하면 아무런 토큰에 대한 터치가 없어서 token의 exp를 기본(30일)로 설정해버린다.
- 그래서 사용자들은 계속 새롭게 내 사이트에 들어오면 30일이라는 시간을 갖게되고 서버에서는 만료가 된 토큰을 잡고 있는다.
- 로그인이 아니라 jwt가 호출될 때도 token의 exp를 계속 최신화 해줘서 고쳤다.

 
